### PR TITLE
docs: add neorg-fzflua to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ much more.
 - [neorg-telescope](https://github.com/nvim-neorg/neorg-telescope) - Telescope.nvim integration for Neorg.
 - [nixpkgs-neorg-overlay](https://github.com/nvim-neorg/nixpkgs-neorg-overlay) - Nixpkgs overlay that gives Nix users access to unstable versions of Neorg and its associated projects.
 - [neorg-taskwarrior](https://github.com/skbolton/neorg-taskwarrior) - Taskwarrior integration into neorg.
+- [neorg-fzflua](https://github.com/kev-cao/neorg-fzflua) - Fzf-lua integration for Neorg.
 
 ## Neorg Modules
 


### PR DESCRIPTION
My [first Neovim plugin](https://github.com/kev-cao/neorg-fzflua) 😄  It's a bit barebones for now, but my goal is to at least reach feature parity with [neorg-telescope](https://github.com/nvim-neorg/neorg-telescope).